### PR TITLE
uclient-fetch: add support for --header cmdline argument

### DIFF
--- a/tests/cram/test-san_uclient-fetch.t
+++ b/tests/cram/test-san_uclient-fetch.t
@@ -12,6 +12,7 @@ check uclient-fetch usage:
   \t-P <dir>\t\t\tSet directory for output files (esc)
   \t--quiet | -q\t\t\tTurn off status messages (esc)
   \t--continue | -c\t\t\tContinue a partially-downloaded file (esc)
+  \t--header='Header: value'\tAdd HTTP header. Multiple allowed (esc)
   \t--user=<user>\t\t\tHTTP authentication username (esc)
   \t--password=<password>\t\tHTTP authentication password (esc)
   \t--user-agent | -U <str>\t\tSet HTTP user agent (esc)

--- a/tests/cram/test_uclient-fetch.t
+++ b/tests/cram/test_uclient-fetch.t
@@ -12,6 +12,7 @@ check uclient-fetch usage:
   \t-P <dir>\t\t\tSet directory for output files (esc)
   \t--quiet | -q\t\t\tTurn off status messages (esc)
   \t--continue | -c\t\t\tContinue a partially-downloaded file (esc)
+  \t--header='Header: value'\tAdd HTTP header. Multiple allowed (esc)
   \t--user=<user>\t\t\tHTTP authentication username (esc)
   \t--password=<password>\t\tHTTP authentication password (esc)
   \t--user-agent | -U <str>\t\tSet HTTP user agent (esc)


### PR DESCRIPTION
Add --header=header-line option to allow adding custom HTTP headers to a request, compatible with wget.
The option can be used multiple times to add multiple headers.