### PR TITLE
uclient-http: fix a typo

### DIFF
--- a/uclient-http.c
+++ b/uclient-http.c
@@ -154,7 +154,7 @@ static void uclient_http_disconnect(struct uclient_http *uh)
 	else
 		ustream_free(&uh->ufd.stream);
 	if(uh->fd >= 0)
-		close(uh->fd >= 0);
+		close(uh->fd);
 	uh->us = NULL;
 }
 


### PR DESCRIPTION
Fixes: 704c781 ("uclient-http: use ustream_ssl without ustream_fd")