### PR TITLE
ucode: fix memory leak when using ssl context

### DIFF
--- a/ucode.c
+++ b/ucode.c
@@ -55,6 +55,11 @@ static void free_uclient(void *ptr)
 		return;
 
 	ucl = cl->priv;
+	if (ucl->ssl_ctx) {
+		ucl->ssl_ops->context_free(ucl->ssl_ctx);
+		ucl->ssl_ctx = NULL;
+		ucl->ssl_ops = NULL;
+	}
 	ucv_array_set(registry, ucl->idx, NULL);
 	ucv_array_set(registry, ucl->idx + 1, NULL);
 	uclient_free(cl);


### PR DESCRIPTION
Check for and free any SSL context when freeing uclient object.

Fixes: https://github.com/openwrt/uclient/issues/11

Tested on x86/64 snapshot r31760-eedc7b3b79ef.