### PR TITLE
Assorted bug fixes: memory safety, HTTP/digest correctness, and CLI behavior

### DIFF
--- a/uclient-fetch.c
+++ b/uclient-fetch.c
@@ -591,12 +591,12 @@ static bool is_valid_header(char *str)
 	char *tmp = str;
 
 	/* First character must be a letter */
-	if (!isalpha(*tmp))
+	if (!isalpha((unsigned char)*tmp))
 		return false;
 
 	/* Subsequent characters must be letters, numbers or dashes */
 	while (*(++tmp) != '\0') {
-		if (!isalnum(*tmp) && *tmp != '-')
+		if (!isalnum((unsigned char)*tmp) && *tmp != '-')
 			return false;
 	}
 
@@ -771,7 +771,7 @@ int main(int argc, char **argv)
 					goto out;
 				}
 				*(tmp++) = '\0';
-				while (isspace(*tmp))
+				while (isspace((unsigned char)*tmp))
 					++tmp;
 
 				if (*tmp == '\0' || !is_valid_header(optarg) || strchr(tmp, '\n')) {

--- a/uclient-fetch.c
+++ b/uclient-fetch.c
@@ -214,7 +214,10 @@ static void header_done_cb(struct uclient *cl)
 	if (cl->status_code == 204 && cur_resume) {
 		/* Resume attempt failed, try normal download */
 		cur_resume = false;
-		init_request(cl);
+		if (init_request(cl)) {
+			error_ret = 4;
+			request_done(cl);
+		}
 		return;
 	}
 

--- a/uclient-fetch.c
+++ b/uclient-fetch.c
@@ -68,6 +68,7 @@ static char *auth_str;
 static char **urls;
 static int n_urls;
 static int timeout;
+static int redirects;
 static bool resume, cur_resume;
 static LIST_HEAD(headers);
 
@@ -182,9 +183,8 @@ static void header_done_cb(struct uclient *cl)
 	};
 	struct blob_attr *tb[__H_MAX];
 	uint64_t resume_offset = 0, resume_end, resume_size;
-	static int retries;
 
-	if (retries < 10) {
+	if (redirects < 10) {
 		int ret = uclient_http_redirect(cl);
 		if (ret < 0) {
 			if (!quiet)
@@ -197,7 +197,7 @@ static void header_done_cb(struct uclient *cl)
 			if (!quiet)
 				fprintf(stderr, "Redirected to %s on %s\n", cl->url->location, cl->url->host);
 
-			retries++;
+			redirects++;
 			return;
 		}
 	}
@@ -335,6 +335,7 @@ static int init_request(struct uclient *cl)
 	out_offset = 0;
 	out_bytes = 0;
 	out_len = 0;
+	redirects = 0;
 	uclient_http_set_ssl_ctx(cl, ssl_ops, ssl_ctx, verify);
 
 	if (timeout)

--- a/uclient-fetch.c
+++ b/uclient-fetch.c
@@ -231,6 +231,7 @@ static void header_done_cb(struct uclient *cl)
 			if (!quiet)
 				fprintf(stderr, "Content-Range header is missing\n");
 			error_ret = 8;
+			request_done(cl);
 			break;
 		}
 
@@ -240,6 +241,7 @@ static void header_done_cb(struct uclient *cl)
 			if (!quiet)
 				fprintf(stderr, "Content-Range header is invalid\n");
 			error_ret = 8;
+			request_done(cl);
 			break;
 		}
 		/* fall through */

--- a/uclient-fetch.c
+++ b/uclient-fetch.c
@@ -467,7 +467,12 @@ static void request_done(struct uclient *cl)
 
 static void eof_cb(struct uclient *cl)
 {
-	if (!quiet) {
+	/*
+	 * The progress meter is only set up in open_output_file(), which is
+	 * skipped when there is no output (e.g. --spider). Don't touch pmt in
+	 * that case, it is still zero-initialized (NULL curfile, unset timer).
+	 */
+	if (!quiet && !no_output) {
 		pmt_update(&pmt_timer);
 		uloop_timeout_cancel(&pmt_timer);
 		fprintf(stderr, "\n");

--- a/uclient-fetch.c
+++ b/uclient-fetch.c
@@ -774,7 +774,8 @@ int main(int argc, char **argv)
 				while (isspace((unsigned char)*tmp))
 					++tmp;
 
-				if (*tmp == '\0' || !is_valid_header(optarg) || strchr(tmp, '\n')) {
+				if (*tmp == '\0' || !is_valid_header(optarg) ||
+				    strchr(tmp, '\n') || strchr(tmp, '\r')) {
 					usage(progname);
 					goto out;
 				}

--- a/uclient-fetch.c
+++ b/uclient-fetch.c
@@ -249,7 +249,7 @@ static void header_done_cb(struct uclient *cl)
 			break;
 
 		if (tb[H_LEN])
-			out_len = strtoul(blobmsg_get_string(tb[H_LEN]), NULL, 10);
+			out_len = strtoull(blobmsg_get_string(tb[H_LEN]), NULL, 10);
 
 		output_fd = open_output_file(cl->url->location, resume_offset);
 		if (output_fd < 0) {

--- a/uclient-fetch.c
+++ b/uclient-fetch.c
@@ -430,6 +430,7 @@ static void request_done(struct uclient *cl)
 			uclient_set_url(cl, *urls, auth_str);
 		}
 		n_urls--;
+		urls++;
 		cur_resume = resume;
 		error_ret = init_request(cl);
 		if (error_ret == 0)

--- a/uclient-fetch.c
+++ b/uclient-fetch.c
@@ -889,14 +889,11 @@ int main(int argc, char **argv)
 	uloop_init();
 
 	if (username) {
-		if (password) {
-			rc = asprintf(&auth_str, "%s:%s", username, password);
-			if (rc < 0) {
-				error_ret = 1;
-				goto out;
-			}
-		} else
-			auth_str = username;
+		rc = asprintf(&auth_str, "%s:%s", username, password ? password : "");
+		if (rc < 0) {
+			error_ret = 1;
+			goto out;
+		}
 	}
 
 	if (!quiet)
@@ -948,6 +945,8 @@ out:
 		list_del(&h->list);
 		free(h);
 	}
+
+	free(auth_str);
 
 	return error_ret;
 }

--- a/uclient-fetch.c
+++ b/uclient-fetch.c
@@ -921,9 +921,9 @@ int main(int argc, char **argv)
 
 	proxy_url = get_proxy_url(argv[0]);
 	if (proxy_url) {
-		cl = uclient_new(proxy_url, auth_str, &cb);
+		cl = uclient_new(proxy_url, NULL, &cb);
 		if (cl)
-		    uclient_set_proxy_url(cl, argv[0], NULL);
+		    uclient_set_proxy_url(cl, argv[0], auth_str);
 	} else {
 		cl = uclient_new(argv[0], auth_str, &cb);
 	}

--- a/uclient-fetch.c
+++ b/uclient-fetch.c
@@ -28,6 +28,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 #include <signal.h>
+#include <errno.h>
 
 #include <libubox/blobmsg.h>
 #include <libubox/list.h>
@@ -272,7 +273,7 @@ static void read_data_cb(struct uclient *cl)
 {
 	char buf[256];
 	ssize_t n;
-	int len;
+	int len, offset;
 
 	if (!no_output && output_fd < 0)
 		return;
@@ -283,10 +284,22 @@ static void read_data_cb(struct uclient *cl)
 			return;
 
 		out_bytes += len;
-		if (!no_output) {
-			n = write(output_fd, buf, len);
-			if (n < 0)
+		if (no_output)
+			continue;
+
+		offset = 0;
+		while (offset < len) {
+			n = write(output_fd, buf + offset, len - offset);
+			if (n < 0) {
+				if (errno == EINTR)
+					continue;
+				if (!quiet)
+					perror("Write to output file failed");
+				error_ret = 2;
+				request_done(cl);
 				return;
+			}
+			offset += n;
 		}
 	}
 }

--- a/uclient-fetch.c
+++ b/uclient-fetch.c
@@ -113,6 +113,14 @@ static int open_output_file(const char *path, uint64_t resume_offset)
 	int flags;
 	int ret;
 
+	/*
+	 * When all URLs are written to a single -O file, keep appending to the
+	 * descriptor opened for the first URL instead of truncating it again
+	 * for every subsequent URL.
+	 */
+	if (output_file && strcmp(output_file, "-") && output_fd >= 0)
+		return output_fd;
+
 	if (cur_resume)
 		flags = O_RDWR;
 	else
@@ -424,8 +432,12 @@ static void request_done(struct uclient *cl)
 	const char *proxy_url;
 
 	if (n_urls) {
-		/* close the finished file before starting the next URL */
-		if (output_fd >= 0 && output_fd != STDOUT_FILENO) {
+		/*
+		 * Close the finished per-URL file before starting the next URL.
+		 * A single -O file (and stdout) is kept open so the URLs are
+		 * concatenated into it.
+		 */
+		if (output_fd >= 0 && output_fd != STDOUT_FILENO && !opt_output_file) {
 			close(output_fd);
 			output_fd = -1;
 		}

--- a/uclient-fetch.c
+++ b/uclient-fetch.c
@@ -869,7 +869,7 @@ int main(int argc, char **argv)
 	argv += optind;
 	argc -= optind;
 
-	if (debug_level)
+	if (debug_level && ssl_ctx)
 		ssl_ops->context_set_debug(ssl_ctx, debug_level, debug_cb, NULL);
 
 	if (verify && !has_cert)

--- a/uclient-fetch.c
+++ b/uclient-fetch.c
@@ -422,6 +422,11 @@ static void request_done(struct uclient *cl)
 	const char *proxy_url;
 
 	if (n_urls) {
+		/* close the finished file before starting the next URL */
+		if (output_fd >= 0 && output_fd != STDOUT_FILENO) {
+			close(output_fd);
+			output_fd = -1;
+		}
 		proxy_url = get_proxy_url(*urls);
 		if (proxy_url) {
 			uclient_set_url(cl, proxy_url, NULL);

--- a/uclient-http.c
+++ b/uclient-http.c
@@ -531,7 +531,7 @@ uclient_http_add_auth_digest(struct uclient_http *uh)
 		const char **dest = NULL;
 		const char *tmp;
 
-		while (*next && isspace(*next))
+		while (*next && isspace((unsigned char)*next))
 			next++;
 
 		if (strmatch(&next, "realm"))
@@ -765,10 +765,10 @@ static void uclient_parse_http_line(struct uclient_http *uh, char *data)
 	*(sep++) = 0;
 
 	for (name = data; *name; name++)
-		*name = tolower(*name);
+		*name = tolower((unsigned char)*name);
 
 	name = data;
-	while (isspace(*sep))
+	while (isspace((unsigned char)*sep))
 		sep++;
 
 	blobmsg_add_string(&uh->meta, name, sep);
@@ -815,7 +815,7 @@ static void __uclient_notify_read(struct uclient_http *uh)
 				if (!*next)
 					return;
 
-				if (isspace(*next) && *next != '\r' && *next != '\n') {
+				if (isspace((unsigned char)*next) && *next != '\r' && *next != '\n') {
 					sep[0] = ' ';
 					if (sep + 1 < next)
 						sep[1] = ' ';

--- a/uclient-http.c
+++ b/uclient-http.c
@@ -431,22 +431,26 @@ static bool strmatch(char **str, const char *prefix)
 	return true;
 }
 
-static void
+static int
 get_cnonce(char *dest)
 {
 	uint32_t val = 0;
 	FILE *f;
-	size_t n;
 
 	f = fopen("/dev/urandom", "r");
-	if (f) {
-		n = fread(&val, sizeof(val), 1, f);
+	if (!f)
+		return -EIO;
+
+	if (fread(&val, sizeof(val), 1, f) != 1) {
 		fclose(f);
-		if (n != 1)
-			return;
+		return -EIO;
 	}
 
+	fclose(f);
+
 	bin_to_hex(dest, &val, sizeof(val));
+
+	return 0;
 }
 
 static void add_field(char **buf, int *ofs, int *len, const char *name, const char *val)
@@ -564,7 +568,9 @@ uclient_http_add_auth_digest(struct uclient_http *uh)
 	}
 
 	sprintf(nc_str, "%08x", uh->nc++);
-	get_cnonce(cnonce_str);
+	err = get_cnonce(cnonce_str);
+	if (err)
+		goto fail;
 
 	data.qop = "auth";
 	data.uri = url->location;

--- a/uclient-http.c
+++ b/uclient-http.c
@@ -1298,6 +1298,10 @@ int uclient_http_redirect(struct uclient *cl)
 	if (!url)
 		return false;
 
+	/* RFC 9110 §15.4.4: a 303 response is retrieved with GET (a HEAD stays HEAD) */
+	if (cl->status_code == 303 && uh->req_type != REQ_HEAD)
+		uh->req_type = REQ_GET;
+
 	if (cl->proxy_url) {
 		free(cl->proxy_url);
 		cl->proxy_url = url;

--- a/uclient-http.c
+++ b/uclient-http.c
@@ -509,6 +509,10 @@ uclient_http_add_auth_digest(struct uclient_http *uh)
 
 	/* skip auth type */
 	strsep(&buf, " ");
+	if (!buf) {
+		err = -EINVAL;
+		goto fail;
+	}
 
 	next = buf;
 	while (*next) {

--- a/uclient-http.c
+++ b/uclient-http.c
@@ -430,6 +430,27 @@ static char *digest_sep(char **str)
 	return cur;
 }
 
+/*
+ * Parse a digest auth parameter value. RFC 7616 quotes realm/nonce/opaque/qop,
+ * but some servers send them as bare tokens; accept both forms.
+ */
+static char *digest_value(char **str)
+{
+	char *val, *end;
+
+	if (**str == '"')
+		return digest_unquote_sep(str);
+
+	val = digest_sep(str);
+
+	/* trim trailing whitespace from the unquoted token */
+	end = val + strlen(val);
+	while (end > val && isspace((unsigned char)end[-1]))
+		*--end = 0;
+
+	return val;
+}
+
 static bool strmatch(char **str, const char *prefix)
 {
 	int len = strlen(prefix);
@@ -570,7 +591,7 @@ uclient_http_add_auth_digest(struct uclient_http *uh)
 			continue;
 		}
 
-		*dest = digest_unquote_sep(&next);
+		*dest = digest_value(&next);
 	}
 
 	if (!realm || !data.qop || !data.nonce) {

--- a/uclient-http.c
+++ b/uclient-http.c
@@ -567,7 +567,7 @@ uclient_http_add_auth_digest(struct uclient_http *uh)
 		goto fail;
 	}
 
-	sprintf(nc_str, "%08x", uh->nc++);
+	sprintf(nc_str, "%08x", ++uh->nc);
 	err = get_cnonce(cnonce_str);
 	if (err)
 		goto fail;

--- a/uclient-http.c
+++ b/uclient-http.c
@@ -350,10 +350,20 @@ static bool uclient_request_supports_body(enum request_type req_type)
 	}
 }
 
+/*
+ * The URL that is actually put on the wire: when a proxy is configured the
+ * request line and Host header use the proxy target (uc.proxy_url), so the
+ * credentials and the digest URI must be taken from the same URL.
+ */
+static struct uclient_url *uclient_http_request_url(struct uclient_http *uh)
+{
+	return uh->uc.proxy_url ? uh->uc.proxy_url : uh->uc.url;
+}
+
 static int
 uclient_http_add_auth_basic(struct uclient_http *uh)
 {
-	struct uclient_url *url = uh->uc.url;
+	struct uclient_url *url = uclient_http_request_url(uh);
 	int auth_len = strlen(url->auth);
 	char *auth_buf;
 
@@ -492,7 +502,7 @@ static void add_field(char **buf, int *ofs, int *len, const char *name, const ch
 static int
 uclient_http_add_auth_digest(struct uclient_http *uh)
 {
-	struct uclient_url *url = uh->uc.url;
+	struct uclient_url *url = uclient_http_request_url(uh);
 	const char *realm = NULL, *opaque = NULL;
 	const char *user, *password;
 	char *buf, *next;
@@ -631,7 +641,7 @@ fail:
 static int
 uclient_http_add_auth_header(struct uclient_http *uh)
 {
-	if (!uh->uc.url->auth)
+	if (!uclient_http_request_url(uh)->auth)
 		return 0;
 
 	switch (uh->auth_type) {

--- a/uclient-http.c
+++ b/uclient-http.c
@@ -22,6 +22,8 @@
 #include <stdint.h>
 #include <string.h>
 #include <fcntl.h>
+#include <errno.h>
+#include <limits.h>
 
 #include <libubox/ustream.h>
 #include <libubox/ustream-ssl.h>
@@ -310,8 +312,18 @@ static void uclient_http_process_headers(struct uclient_http *uh)
 		uh->connection_close = true;
 
 	cur = tb[HTTP_HDR_CONTENT_LENGTH];
-	if (cur)
-		uh->content_length = strtoul(blobmsg_data(cur), NULL, 10);
+	if (cur) {
+		const char *val = blobmsg_data(cur);
+		char *end;
+		long long len;
+
+		errno = 0;
+		len = strtoll(val, &end, 10);
+		if (end == val || *end || errno || len < 0 || len > LONG_MAX)
+			uh->content_length = -1;
+		else
+			uh->content_length = len;
+	}
 
 	cur = tb[HTTP_HDR_AUTH];
 	if (cur) {
@@ -1156,7 +1168,8 @@ uclient_http_read(struct uclient *cl, char *buf, unsigned int len)
 	read_len = 0;
 
 	if (uh->read_chunked == 0) {
-		char *sep;
+		char *sep, *end;
+		long long chunk_len;
 
 		if (data[0] == '\r' && data[1] == '\n') {
 			data += 2;
@@ -1168,7 +1181,13 @@ uclient_http_read(struct uclient *cl, char *buf, unsigned int len)
 			return 0;
 
 		*sep = 0;
-		uh->read_chunked = strtoul(data, NULL, 16);
+		errno = 0;
+		chunk_len = strtoll(data, &end, 16);
+		if (end == data || chunk_len < 0 || chunk_len > LONG_MAX || errno) {
+			uclient_http_error(uh, UCLIENT_ERROR_UNKNOWN);
+			return 0;
+		}
+		uh->read_chunked = chunk_len;
 
 		read_len += sep + 2 - data;
 		data = sep + 2;

--- a/uclient-http.c
+++ b/uclient-http.c
@@ -1040,6 +1040,7 @@ static struct uclient *uclient_http_alloc(void)
 	if (!uh)
 		return NULL;
 
+	uh->fd = -1;
 	uh->disconnect_t.cb = uclient_http_disconnect_cb;
 	blob_buf_init(&uh->headers, 0);
 

--- a/uclient-http.c
+++ b/uclient-http.c
@@ -1250,7 +1250,7 @@ int uclient_http_redirect(struct uclient *cl)
 		.name = "location",
 		.type = BLOBMSG_TYPE_STRING,
 	};
-	struct uclient_url *url = cl->url;
+	struct uclient_url *url = cl->proxy_url ? cl->proxy_url : cl->url;
 	struct blob_attr *tb;
 
 	if (cl->backend != &uclient_backend_http)

--- a/uclient-http.c
+++ b/uclient-http.c
@@ -463,7 +463,8 @@ static void add_field(char **buf, int *ofs, int *len, const char *name, const ch
 	if (*len && !*buf)
 		return;
 
-	required = strlen(name) + 4 + strlen(val) * 2;
+	/* ", name=\"" + escaped value (up to 2 bytes each) + closing '"' + NUL */
+	required = strlen(name) + 6 + strlen(val) * 2;
 	if (required > available)
 		*len += required - available + 64;
 

--- a/uclient-http.c
+++ b/uclient-http.c
@@ -711,7 +711,7 @@ static void uclient_http_process_headers_cb(struct uloop_timeout *timeout)
 	uclient_http_process_headers(uh);
 
 	if (auth_type == AUTH_TYPE_UNKNOWN && uh->uc.status_code == 401 &&
-	    (uh->req_type == REQ_HEAD || uh->req_type == REQ_GET)) {
+	    !uclient_request_supports_body(uh->req_type)) {
 		uclient_http_connect(&uh->uc);
 		uclient_http_send_headers(uh);
 		uh->state = HTTP_STATE_REQUEST_DONE;

--- a/uclient-utils.c
+++ b/uclient-utils.c
@@ -78,7 +78,7 @@ int uclient_urldecode(const char *in, char *out, bool decode_plus)
 
 	while ((c = *(in++))) {
 		if (c == '%') {
-			if (!isxdigit(in[0]) || !isxdigit(in[1]))
+			if (!isxdigit((unsigned char)in[0]) || !isxdigit((unsigned char)in[1]))
 				return -1;
 
 			dec[0] = in[0];

--- a/uclient-utils.c
+++ b/uclient-utils.c
@@ -169,12 +169,11 @@ char *uclient_get_url_filename(const char *url, const char *default_name)
 	while (len > 0 && url[len - 1] == '/')
 		len--;
 
-	for (str = url + len - 1; str >= url; str--) {
-		if (*str == '/')
-			break;
-	}
+	/* walk back to just after the last '/', without forming url - 1 */
+	str = url + len;
+	while (str > url && str[-1] != '/')
+		str--;
 
-	str++;
 	len -= str - url;
 
 	if (len > 0)

--- a/uclient.c
+++ b/uclient.c
@@ -346,6 +346,7 @@ int uclient_connect(struct uclient *cl)
 void uclient_free(struct uclient *cl)
 {
 	struct uclient_url *url = cl->url;
+	struct uclient_url *proxy_url = cl->proxy_url;
 
 	if (cl->backend->free)
 		cl->backend->free(cl);
@@ -353,6 +354,7 @@ void uclient_free(struct uclient *cl)
 		free(cl);
 
 	free(url);
+	free(proxy_url);
 }
 
 int uclient_write(struct uclient *cl, const char *buf, int len)

--- a/uclient.c
+++ b/uclient.c
@@ -350,6 +350,12 @@ void uclient_free(struct uclient *cl)
 	struct uclient_url *url = cl->url;
 	struct uclient_url *proxy_url = cl->proxy_url;
 
+	/* Cancel timers embedded in cl before the backend frees the memory,
+	 * otherwise a still-pending timeout would reference freed memory. */
+	uloop_timeout_cancel(&cl->connection_timeout);
+	uloop_timeout_cancel(&cl->timeout);
+	uloop_timeout_cancel(&cl->read_notify);
+
 	if (cl->backend->free)
 		cl->backend->free(cl);
 	else

--- a/uclient.c
+++ b/uclient.c
@@ -43,6 +43,8 @@ char *uclient_get_addr(char *dest, int *port, union uclient_addr *a)
 		portval = a->sin6.sin6_port;
 		break;
 	default:
+		if (port)
+			*port = 0;
 		return strcpy(dest, "Unknown");
 	}
 

--- a/uclient.c
+++ b/uclient.c
@@ -257,8 +257,10 @@ struct uclient *uclient_new(const char *url_str, const char *auth_str, const str
 		return NULL;
 
 	cl = url->backend->alloc();
-	if (!cl)
+	if (!cl) {
+		free(url);
 		return NULL;
+	}
 
 	cl->backend = url->backend;
 	cl->cb = cb;

--- a/uclient.h
+++ b/uclient.h
@@ -138,7 +138,9 @@ static inline bool uclient_http_status_redirect(struct uclient *cl)
 	switch (cl->status_code) {
 	case 301:
 	case 302:
+	case 303:
 	case 307:
+	case 308:
 		return true;
 	default:
 		return false;

--- a/ucode.c
+++ b/ucode.c
@@ -220,7 +220,7 @@ uc_uclient_get_headers(uc_vm_t *vm, size_t nargs)
 			continue;
 
 		str = ucv_string_new(blobmsg_get_string(cur));
-		ucv_object_add(ret, blobmsg_name(cur), ucv_get(str));
+		ucv_object_add(ret, blobmsg_name(cur), str);
 	}
 
 	return ret;
@@ -409,12 +409,12 @@ uc_uclient_status(uc_vm_t *vm, size_t nargs)
 	ucv_object_add(ret, "redirect", ucv_boolean_new(uclient_http_status_redirect(cl)));
 
 	uclient_get_addr(addr, &port, &cl->local_addr);
-	ucv_object_add(ret, "local_addr", ucv_get(ucv_string_new(addr)));
-	ucv_object_add(ret, "local_port", ucv_get(ucv_int64_new(port)));
+	ucv_object_add(ret, "local_addr", ucv_string_new(addr));
+	ucv_object_add(ret, "local_port", ucv_int64_new(port));
 
 	uclient_get_addr(addr, &port, &cl->remote_addr);
-	ucv_object_add(ret, "remote_addr", ucv_get(ucv_string_new(addr)));
-	ucv_object_add(ret, "remote_port", ucv_get(ucv_int64_new(port)));
+	ucv_object_add(ret, "remote_addr", ucv_string_new(addr));
+	ucv_object_add(ret, "remote_port", ucv_int64_new(port));
 
 	return ret;
 }

--- a/ucode.c
+++ b/ucode.c
@@ -148,6 +148,8 @@ uc_uclient_ssl_init(uc_vm_t *vm, size_t nargs)
 
 err:
 	ops->context_free(ctx);
+	ucl->ssl_ctx = NULL;
+	ucl->ssl_ops = NULL;
 	return NULL;
 }
 

--- a/ucode.c
+++ b/ucode.c
@@ -427,7 +427,7 @@ uc_uclient_read(uc_vm_t *vm, size_t nargs)
 		len = sizeof(buf);
 
 	while (len > 0) {
-		cur = uclient_read(cl, buf, len);
+		cur = uclient_read(cl, buf, len > sizeof(buf) ? sizeof(buf) : len);
 		if (cur <= 0)
 			break;
 

--- a/ucode.c
+++ b/ucode.c
@@ -255,18 +255,18 @@ __uc_uclient_cb(struct uclient *cl, const char *name, uc_value_t *arg)
 {
 	struct uc_uclient_priv *ucl = cl->priv;
 	uc_vm_t *vm = uc_vm;
-	uc_value_t *cb, *cb_obj;
+	uc_value_t *cb, *cb_obj, *ret = NULL;
 
 	cb_obj = ucv_array_get(registry, ucl->idx);
 	if (!cb_obj)
-		return NULL;
+		goto out;
 
 	cb = ucv_property_get(cb_obj, name);
 	if (!cb)
-		return NULL;
+		goto out;
 
 	if (!ucv_is_callable(cb))
-		return NULL;
+		goto out;
 
 	uc_vm_stack_push(vm, ucv_get(ucl->resource));
 	uc_vm_stack_push(vm, ucv_get(cb));
@@ -277,10 +277,17 @@ __uc_uclient_cb(struct uclient *cl, const char *name, uc_value_t *arg)
 	if (uc_vm_call(vm, true, !!arg + 1) != EXCEPTION_NONE) {
 		if (vm->exhandler)
 			vm->exhandler(vm, &vm->exception);
-		return NULL;
+		goto out;
 	}
 
-	return uc_vm_stack_pop(vm);
+	ret = uc_vm_stack_pop(vm);
+
+out:
+	/* the callers hand over their reference on arg */
+	if (arg)
+		ucv_put(arg);
+
+	return ret;
 }
 
 static void

--- a/ucode.c
+++ b/ucode.c
@@ -58,7 +58,6 @@ static void free_uclient(void *ptr)
 	if (ucl->ssl_ctx)
 		ucl->ssl_ops->context_free(ucl->ssl_ctx);
 	ucv_array_set(registry, ucl->idx, NULL);
-	ucv_array_set(registry, ucl->idx + 1, NULL);
 	uclient_free(cl);
 	free(ucl);
 }

--- a/ucode.c
+++ b/ucode.c
@@ -508,6 +508,9 @@ uc_uclient_new(uc_vm_t *vm, size_t nargs)
 		return NULL;
 
 	ucl = calloc(1, sizeof(*ucl));
+	if (!ucl)
+		return NULL;
+
 	if (ucv_property_get(cb, "data_read"))
 		ucl->cb.data_read = uc_cb_data_read;
 	if (ucv_property_get(cb, "get_post_data"))


### PR DESCRIPTION
## Summary

A batch of independent bug fixes across the library (`uclient`/`uclient-http`/
`uclient-utils`), the `uclient-fetch` CLI, and the ucode binding, found through
an AI-assisted review and verified by hand. Each fix is a self-contained commit
with its own rationale, so they can be reviewed, reordered, or dropped
individually. No new features; the only public-header change is two added
redirect status codes (303/308).

## Memory safety & leaks
- `uclient_free()`: free `proxy_url`, and cancel the embedded
  connection/timeout/read-notify timers before the backend frees the client
  (use-after-free if a client is freed mid-request).
- `uclient_new()`: free the parsed URL when the backend allocation fails.
- HTTP backend: initialize `fd` to `-1` so a failed first connect can't
  `close(0)` (stdin/whatever occupies fd 0).
- ucode: fix SSL-context double-free on `ssl_init` error; stop clearing an
  unrelated registry slot on free (which silently disabled another live
  client's callbacks); release callback-argument references (per-chunk leak
  during uploads); stop leaking string refs in `status()`/`get_headers()`.
- `uclient-fetch`: always heap-allocate and free `auth_str`; close the per-URL
  output file before fetching the next URL.

## Buffer overflows / out-of-bounds
- Digest `add_field()`: fix a 1–2 byte heap overflow (the closing quote and NUL
  were not accounted for); server-controlled realm/nonce/opaque can hit it.
- `get_url_filename()`: avoid forming an out-of-bounds pointer (e.g. for
  `http://host/`), which trips the CI UBSan/ASan build.
- Digest cnonce: never hash/read the buffer uninitialized — fail when
  `/dev/urandom` can't be read instead of emitting a predictable cnonce.
- ucode `read()`: clamp the read length to the static buffer size.
- Digest: fix a NULL deref when `WWW-Authenticate: Digest` carries no params.

## HTTP / digest correctness
- Follow 303 (retrieved with GET, HEAD stays HEAD) and 308 (method-preserving)
  redirects.
- Send digest `nc` starting at `00000001` (strict servers reject `00000000`).
- Through a proxy, take credentials + the digest `uri` and resolve relative
  redirects from the proxy *target* URL, and attach credentials to the target
  rather than the proxy (origin 401 auth now works through a proxy).
- Retry after a 401 for all body-less methods (OPTIONS, COPY/MOVE/UNLOCK), not
  just GET/HEAD.
- Accept unquoted digest parameter values from lenient servers.
- Abort the transfer on an invalid 206 `Content-Range`; reset the redirect
  counter per request.

## Robustness / server-input validation
- Validate `Content-Length` and chunk sizes (reject negative/overflow/garbage);
  parse `Content-Length` with `strtoull` to avoid 32-bit truncation.
- Cast to `unsigned char` before ctype classification (UB on negative `char`).
- Initialize `*port` for unknown address families.
- Retry short writes and surface write errors instead of silently truncating
  the output file.

## Security hardening
- Reject CR (in addition to LF) in `--header` values to prevent request
  splitting.

## uclient-fetch CLI behavior
- Advance through all URLs (previously the 3rd+ URL was never fetched);
  concatenate multiple URLs into a single `-O` file (wget-compatible).
- Handle `init_request()` failure on the 204 resume retry (otherwise the event
  loop hangs forever).
- Skip the progress meter in `--spider` mode (NULL `curfile` was UB).
- Guard SSL debug setup when no SSL backend is available.

## Known, intentionally-unchanged limitations
- 307/308 redirects don't replay a streamed request body (pre-existing; 308
  inherits 307's behavior).
- An invalid `Content-Length` is treated as unknown-length rather than the hard
  framing error RFC 9110/7230 prescribes — safe, but lenient. Happy to tighten
  if preferred.